### PR TITLE
Documentation and CLI fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -206,6 +206,16 @@ Then look the result in ``/tmp/iloscan.log`` (can be changed in the source):
     > less /tmp/iloscan.log
     192.168.66.69{{ RIMP} [{{ HSI} ProLiant DL380 G7}] [{{ MP} 1.80 ILOCZ2069K2S4       ILO583970CZ2069K2S4}]}
 
+Alternatively, you can invoke the binary with a subnet on the command line (individual IP addresses should be specified as a /32 netmask):
+
+::
+
+    > ./iloscan 1.2.3.4/32
+    Generated 1.2.3.4
+    Fetching 1.2.3.4
+    1.2.3.4 status: 200 OK
+    {{ RIMP} [{{ HSI} ProLiant DL380 Gen9}] [{{ MP} 2.40 ILOCZJ641057H ILO826683CZJ641057H}]}
+
 
 Authors
 -------

--- a/scanner/iloscan.go
+++ b/scanner/iloscan.go
@@ -20,7 +20,7 @@ import (
 // List of targets in CIDR format
 // can be commented and used args instead in the main func
 var (
-	targets = []string{
+	defaultTargets = []string{
 		"10.0.0.0/8"}
 )
 
@@ -154,7 +154,10 @@ func GenerateUrlsFromTargets(targets []string) {
 
 func main() {
 
-	targets := []string{os.Args[1]}
+	var targets []string = defaultTargets
+	if len(os.Args) > 1 {
+		targets = []string{os.Args[1]}
+	}
 
 	// Remember your path location
 	var _, err = os.Stat(path)


### PR DESCRIPTION
Added slightly to CLI docs.
Stop the scanner dying when no target specified on command line.