### PR TITLE
Fix iLO5 script struct usage portability

### DIFF
--- a/scripts/iLO5/ilo5_PoC_fum_sig_bypass.py
+++ b/scripts/iLO5/ilo5_PoC_fum_sig_bypass.py
@@ -95,7 +95,7 @@ print "[+] compiling trampoline"
 nop_ins = ''.join(chr(x) for x in ks.asm("SUBPL    r3, r1, #56")[0])
 bad_reg = "BEEF"
 
-ret_addr = struct.pack('L', HPIMAGE_BLOB_TMP_ADDR+0x100)[:3]
+ret_addr = struct.pack('<L', HPIMAGE_BLOB_TMP_ADDR+0x100)[:3]
 
 
 # generate trampoline, ret from extract_hp_signed_file to fum_load_hpimg

--- a/scripts/iLO5/ilo5_fw_decrypt.py
+++ b/scripts/iLO5/ilo5_fw_decrypt.py
@@ -40,7 +40,7 @@ RSA_FILE = 'rsa_private_key_ilo5.asc'
 
 
 def pem_password_cb():
-    return struct.pack("L" * 8, *list(x ^ y for x, y in zip(KEY_MASK, HW_KEY)))
+    return struct.pack("<LLLLLLLL", *list(x ^ y for x, y in zip(KEY_MASK, HW_KEY)))
 
 
 def load_private_key():


### PR DESCRIPTION
Unsigned long is 32-bit on Windows, but 64-bit on 64-bit POSIX systems.